### PR TITLE
fix: guard against null in UserMapper update

### DIFF
--- a/backend/user-service/src/main/java/com/neighborconnect/userservice/mapper/UserMapper.java
+++ b/backend/user-service/src/main/java/com/neighborconnect/userservice/mapper/UserMapper.java
@@ -60,7 +60,9 @@ public class UserMapper {
     
     // Partial update - only updates non-null fields
     public static void updateEntityFromDto(User entity, UserDto dto) {
-        if (dto == null) {
+        // Guard against null values to prevent NullPointerException
+        // when either the target entity or the source DTO is missing
+        if (entity == null || dto == null) {
             return;
         }
         


### PR DESCRIPTION
## Summary
- avoid `NullPointerException` when partially updating user entities

## Testing
- `mvn -q -e test` *(fails: dependencies missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a11c84bbb08325aa374f1101336588